### PR TITLE
Use Java 17 in the build Github action

### DIFF
--- a/.github/workflows/kotlin-multiplatform-build.yml
+++ b/.github/workflows/kotlin-multiplatform-build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'zulu'
 
       - name: Cache Gradle dependencies


### PR DESCRIPTION
# Summary
The latest Java version supported in Android at the moment (SDK 34) is Java 17 (as specified [here](https://developer.android.com/build/jdks#compileSdk)). Using Java 21 in the Github Action to build the project caused issues like [in this case](https://github.com/piloudu/kmp-clean-app-template/actions/runs/9241862228)