### PR TITLE
Use MacOS in the build Github Action

### DIFF
--- a/.github/workflows/kotlin-multiplatform-build.yml
+++ b/.github/workflows/kotlin-multiplatform-build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Summary
As iOS targets can only be compiled using macOS at the moment, the Github action is showing the following warning:

```
w: The following Kotlin/Native targets cannot be built on this machine and are disabled: iosArm64, iosSimulatorArm64, iosX64
```

This can be fixed by changing from linux to macOS machines