### PR TITLE
Downgradle AGP version to the latest compatible with KMP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
-androidGradlePlugin = "8.4.1"
+# Latest version compatible with KMP (see https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility)
+androidGradlePlugin = "8.3.0"
+
 androidxActivity = "1.9.0"
 androidxComposeBom = "2024.05.00"
 androidxComposeCompiler = "1.5.14"


### PR DESCRIPTION
# Summary
There was a compilation warning specifying an incompatibility between KMP and the AGP in use:

```
w: Kotlin Multiplatform <-> Android Gradle Plugin compatibility issue: The applied Android Gradle Plugin version (8.4.1) is higher than the maximum known to the Kotlin Gradle Plugin.
```

The version is now downgraded to the latest compatible version specified in the [Compatibility guide for Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility) guide